### PR TITLE
Expose some RocksDB backup functionality in OCaml; add tests for it

### DIFF
--- a/install_rocksdb.sh
+++ b/install_rocksdb.sh
@@ -2,7 +2,7 @@
 
 echo $(gcc --version)
 
-VERSION=5.11.3
+VERSION=5.17.2
 shared_lib_file="/usr/local/lib/librocksdb.so.${VERSION}"
 if [ -e $shared_lib_file ]; then
     echo "$shared_lib_file exists"

--- a/rocks.ml
+++ b/rocks.ml
@@ -488,17 +488,20 @@ and RocksDb : Rocks_intf.ROCKS with type batch := WriteBatch.t = struct
       | None -> Options.with_t inner
       | Some opts -> inner opts
 
-    let create_new_backup =
+    let do_create_new_backup =
       foreign
         "rocksdb_backup_engine_create_new_backup"
-        (t @-> db @-> returning void)
+        (t @-> db @-> ptr string_opt @-> returning void)
+
+    let create_new_backup t db =
+      with_err_pointer (do_create_new_backup t db)
 
     let do_verify_backup =
       foreign "rocksdb_backup_engine_verify_backup"
         (t @-> uint32_t @-> ptr string_opt @-> returning void)
 
-    let verify_backup backup n =
-      with_err_pointer (do_verify_backup backup n)
+    let verify_backup t n =
+      with_err_pointer (do_verify_backup t n)
 
     let restore_options_create_no_gc =
       foreign "rocksdb_restore_options_create"
@@ -532,15 +535,15 @@ and RocksDb : Rocks_intf.ROCKS with type batch := WriteBatch.t = struct
       foreign "rocksdb_backup_engine_restore_db_from_latest_backup"
         (t @-> string @-> string @-> restore_opts @-> ptr string_opt @-> returning void)
 
-    let restore_db_from_latest_backup backup db_dir log_dir opts =
-      with_err_pointer (do_restore_db_from_latest_backup backup db_dir log_dir opts)
+    let restore_db_from_latest_backup t db_dir log_dir opts =
+      with_err_pointer (do_restore_db_from_latest_backup t db_dir log_dir opts)
 
     let do_purge_old_backups =
       foreign "rocksdb_backup_engine_purge_old_backups"
-        (t @-> int @-> ptr string_opt @-> returning void)
+        (t @-> uint32_t @-> ptr string_opt @-> returning void)
 
-    let purge_old_backups backup keep =
-      with_err_pointer (do_purge_old_backups backup keep)
+    let purge_old_backups t keep =
+      with_err_pointer (do_purge_old_backups t keep)
 
     let get_backup_info =
       foreign "rocksdb_backup_engine_get_backup_info"

--- a/rocks_intf.ml
+++ b/rocks_intf.ml
@@ -98,7 +98,7 @@ module type ROCKS = sig
     (** first string is db dir, second is log dir, usually the same *)
     val restore_db_from_latest_backup :
       t -> string -> string -> restore_opts -> unit
-    val purge_old_backups : t -> int -> unit
+    val purge_old_backups : t -> Unsigned.uint32 -> unit
     val get_backup_info : t -> info
     val info_count : info -> int
     val info_backup_id : info -> int -> Unsigned.uint32

--- a/rocks_intf.ml
+++ b/rocks_intf.ml
@@ -84,6 +84,26 @@ module type ROCKS = sig
   type t
   type batch
 
+  module BackupEngine : sig
+    type db = t
+    type info
+    type restore_opts
+    type t
+
+    val open_ : ?opts:Options.t -> string -> t
+    val create_new_backup : t -> db -> unit
+    val verify_backup : t -> Unsigned.uint32 -> unit
+    val restore_options_create : unit -> restore_opts
+    val set_keep_log_files : restore_opts -> bool -> unit
+    (** first string is db dir, second is log dir, usually the same *)
+    val restore_db_from_latest_backup :
+      t -> string -> string -> restore_opts -> unit
+    val purge_old_backups : t -> int -> unit
+    val get_backup_info : t -> info
+    val info_count : info -> int
+    val info_backup_id : info -> int -> Unsigned.uint32
+  end
+
   val get_pointer : t -> unit Ctypes.ptr
 
   val open_db : ?opts:Options.t -> string -> t

--- a/rocks_test.ml
+++ b/rocks_test.ml
@@ -27,6 +27,26 @@ let main () =
        | None -> "None") in
   print_string_option (read "mykey");
   print_string_option (read "mykey2");
+
+  (* backup tests:
+     remove any existing backups
+     create new backup, verify it
+     restore db from backup
+  *)
+
+  let open BackupEngine in
+
+  let backup_dir = "/tmp/rocks_backup_test" in
+  let backup_eng = open_ ~opts:open_opts backup_dir in
+  ignore (purge_old_backups backup_eng 0);
+  ignore (create_new_backup backup_eng db);
+  let info = get_backup_info backup_eng in
+  let count = info_count info in
+  let id = info_backup_id info (count - 1) in
+  ignore (verify_backup backup_eng id);
+  let restore_opts = restore_options_create () in
+  ignore (restore_db_from_latest_backup backup_eng backup_dir backup_dir restore_opts);
+
   close db
 
 let () =

--- a/rocks_test.ml
+++ b/rocks_test.ml
@@ -38,7 +38,7 @@ let main () =
 
   let backup_dir = "/tmp/rocks_backup_test" in
   let backup_eng = open_ ~opts:open_opts backup_dir in
-  ignore (purge_old_backups backup_eng 0);
+  ignore (purge_old_backups backup_eng Unsigned.UInt32.zero);
   ignore (create_new_backup backup_eng db);
   let info = get_backup_info backup_eng in
   let count = info_count info in


### PR DESCRIPTION
Added basic backup/restore functionality to OCaml interface. Testing in `rocks_test.ml`.

There is additional functionality available, but this may be enough.

Note that the OCaml interface is not entirely type-safe, because the type `Rocks_common.t` is used for C pointer with a validity everywhere. That was true before this PR, but I encountered bugs not caught by the type system.